### PR TITLE
due日付の解析処理を修正し、UTC形式の変換を改善

### DIFF
--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -24,6 +24,7 @@ const MS_TODO_TASKS_ENDPOINT = "https://graph.microsoft.com/v1.0/me/todo/lists/$
 // 列名定数
 const COL_NAME_RESULT = "result";
 
+
 // メッセージ定数（ユーザー向け・エラー・結果・バリデーション）
 const MSG_SHEET_NOT_FOUND = "{sheetName}シートが存在しません";
 const MSG_TOKEN_NOT_FOUND = "Authシートにトークン情報がありません。初回認証が必要です。";
@@ -41,6 +42,10 @@ const MSG_INVALID_REMINDER_DATE = "reminder日付が不正です";
 const TASK_RESULT_SUCCESS = "Success";
 const TASK_RESULT_ERROR = "Error: {msg}";
 const REGEX_REMOVE_MILLISECONDS = /\.\d{3}Z$/;
+
+// 日付フォーマット定数
+const DATE_FORMAT_DATE = "yyyy-MM-dd";
+const DATE_FORMAT_DATETIME = "yyyy-MM-dd HH:mm:ss";
 
 /**
  * 数値変換し、NaNならデフォルト値を返す
@@ -194,8 +199,8 @@ function buildTaskPayload(task) {
         if (isNaN(dueDate.getTime())) {
             throw new Error(MSG_INVALID_DUE_DATE);
         }
-    const dueLocalDateTimeStr = Utilities.formatDate(dueDate, tz, "yyyy-MM-dd") + " 23:59:00";
-    const dueUtcDate = Utilities.parseDate(dueLocalDateTimeStr, tz, "yyyy-MM-dd HH:mm:ss");
+    const dueLocalDateTimeStr = Utilities.formatDate(dueDate, tz, DATE_FORMAT_DATE) + " 23:59:00";
+    const dueUtcDate = Utilities.parseDate(dueLocalDateTimeStr, tz, DATE_FORMAT_DATETIME);
         // toISOString()はミリ秒付き（.000Z）になるため、replaceでミリ秒を除去しISO8601形式（秒まで）に整形
         // 例: 2025-08-17T00:00:00.000Z → 2025-08-17T00:00:00Z
         const dueIso = dueUtcDate.toISOString().replace(REGEX_REMOVE_MILLISECONDS, "Z");

--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -24,7 +24,6 @@ const MS_TODO_TASKS_ENDPOINT = "https://graph.microsoft.com/v1.0/me/todo/lists/$
 // 列名定数
 const COL_NAME_RESULT = "result";
 
-
 // メッセージ定数（ユーザー向け・エラー・結果・バリデーション）
 const MSG_SHEET_NOT_FOUND = "{sheetName}シートが存在しません";
 const MSG_TOKEN_NOT_FOUND = "Authシートにトークン情報がありません。初回認証が必要です。";

--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -194,8 +194,8 @@ function buildTaskPayload(task) {
         if (isNaN(dueDate.getTime())) {
             throw new Error(MSG_INVALID_DUE_DATE);
         }
-        const dueLocalDateTimeStr = Utilities.formatDate(dueDate, tz, "yyyy-MM-dd") + " 23:59:00";
-        const dueUtcDate = Utilities.parseDate(dueLocalDateTimeStr, tz);
+    const dueLocalDateTimeStr = Utilities.formatDate(dueDate, tz, "yyyy-MM-dd") + " 23:59:00";
+    const dueUtcDate = Utilities.parseDate(dueLocalDateTimeStr, tz, "yyyy-MM-dd HH:mm:ss");
         // toISOString()はミリ秒付き（.000Z）になるため、replaceでミリ秒を除去しISO8601形式（秒まで）に整形
         // 例: 2025-08-17T00:00:00.000Z → 2025-08-17T00:00:00Z
         const dueIso = dueUtcDate.toISOString().replace(REGEX_REMOVE_MILLISECONDS, "Z");


### PR DESCRIPTION
## 概要
- buildTaskPayload 関数で期日（due date）の解析方法を更新し、正しい日付時刻フォーマットが使用されるようにします。

## 変更内容
- buildTaskPayload 内の Utilities.parseDate の呼び出しを更新し、期日を解析する際に日付時刻フォーマット "yyyy-MM-dd HH:mm:ss" を明示的に指定することで、より信頼性が高く正確な解析を実現しました。

## 動作確認
- どのような手順で動作確認を行ったか記述してください。
- 動作確認に使用した環境（OS, ブラウザ等）

## 関連するIssue
- Fixes #4 
