### PR TITLE
Fixes/#6

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,13 @@ Googleスプレッドシートのカスタムメニューから「Tasksシート
 | エラー | Authシートにトークン情報がありません。初回認証が必要です。 | トークン未取得時 |
 | エラー | トークン取得リクエストに失敗しました: {msg} | トークン取得APIエラー時 |
 | エラー | アクセストークン取得に失敗しました: {msg} | アクセストークン取得失敗時 |
+| エラー | {sheetName}シートが存在しません | Tasksシートが存在しない場合 |
 | エラー | Tasksシートに'result'列がありません。'result'列を追加してください。 | result列未作成時 |
 | エラー | title/list_name missing | 必須項目未入力時 |
 | エラー | due日付が不正です | 期限日が不正な場合 |
 | エラー | reminder日付が不正です | リマインダー日付が不正な場合 |
 | エラー | 指定リストが見つかりません: {listName} | list_name不正時 |
-| エラー | {sheetName}シートが存在しません | Tasksシートが存在しない場合 |
+| エラー | Microsoft To Do登録APIエラー: HTTP {code}\n{body} | Microsoft To Do API呼び出し時にHTTPエラーが発生した場合（result列） |
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要
- Microsoft To Do APIとの通信におけるエラー処理を改善します。HTTPステータスコードのチェックを追加し、失敗した場合にエラーメッセージを出力します。

## 変更内容
-  To Do API から返される HTTP エラーの報告を標準化するため、新しいエラーメッセージ定数 `MSG_TODO_API_ERROR` を追加しました。
-  `getAccessToken`、`getTodoListId`、`registerTaskToMicrosoftToDo`、および`exchangeCodeForTokenFromSheet`関数を更新し、`muteHttpExceptions: true`を使用するように変更しました。HTTPレスポンスコードを確認し、レスポンスが成功しなかった場合、`MSG_TODO_API_ERROR`を使用して説明的なエラーを投げます。
- `README.md`のエラー一覧を更新し、Microsoft To Do APIのHTTPエラーに関する新しいエラーメッセージを記載しました。

## 関連するIssue
- Fixes #6 