### PR TITLE
Fixes/#8

### DIFF
--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -235,7 +235,9 @@ function buildTaskPayload(task) {
         let startDateStr, endDateStr;
         try {
             const startDateObj = new Date(task.recurrence_start);
-            if (isNaN(startDateObj.getTime())) throw new Error("recurrence_start invalid");
+            if (isNaN(startDateObj.getTime())) {
+                throw new Error("recurrence_start invalid");
+            }
             startDateStr = Utilities.formatDate(startDateObj, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), DATE_FORMAT_DATE);
         } catch (e) {
             throw new Error("recurrence_start invalid");
@@ -243,7 +245,9 @@ function buildTaskPayload(task) {
         if (task.recurrence_end) {
             try {
                 const endDateObj = new Date(task.recurrence_end);
-                if (isNaN(endDateObj.getTime())) throw new Error("recurrence_end invalid");
+                if (isNaN(endDateObj.getTime())) {
+                    throw new Error("recurrence_end invalid");
+                }
                 endDateStr = Utilities.formatDate(endDateObj, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), DATE_FORMAT_DATE);
             } catch (e) {
                 throw new Error("recurrence_end invalid");

--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -231,6 +231,24 @@ function buildTaskPayload(task) {
 
     // 繰り返し設定があれば追加
     if (task.recurrence_type && task.recurrence_start) {
+        // recurrence_start, recurrence_end を yyyy-MM-dd 形式に変換
+        let startDateStr, endDateStr;
+        try {
+            const startDateObj = new Date(task.recurrence_start);
+            if (isNaN(startDateObj.getTime())) throw new Error("recurrence_start invalid");
+            startDateStr = Utilities.formatDate(startDateObj, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), DATE_FORMAT_DATE);
+        } catch (e) {
+            throw new Error("recurrence_start invalid");
+        }
+        if (task.recurrence_end) {
+            try {
+                const endDateObj = new Date(task.recurrence_end);
+                if (isNaN(endDateObj.getTime())) throw new Error("recurrence_end invalid");
+                endDateStr = Utilities.formatDate(endDateObj, SpreadsheetApp.getActive().getSpreadsheetTimeZone(), DATE_FORMAT_DATE);
+            } catch (e) {
+                throw new Error("recurrence_end invalid");
+            }
+        }
         payload.recurrence = {
             pattern: {
                 type: task.recurrence_type.toLowerCase(),
@@ -238,8 +256,8 @@ function buildTaskPayload(task) {
             },
             range: {
                 type: task.recurrence_end ? "endDate" : "noEnd",
-                startDate: task.recurrence_start,
-                endDate: task.recurrence_end || undefined
+                startDate: startDateStr,
+                endDate: endDateStr
             }
         };
     }

--- a/MicrosoftToDoImporter.gs
+++ b/MicrosoftToDoImporter.gs
@@ -252,6 +252,8 @@ function buildTaskPayload(task) {
             } catch (e) {
                 throw new Error("recurrence_end invalid");
             }
+        } else {
+            endDateStr = undefined;
         }
         payload.recurrence = {
             pattern: {


### PR DESCRIPTION
## 概要
- `buildTaskPayload` 関数における再発日フィールドの処理を改善し、`recurrence_start` と `recurrence_end` がパケットに追加される前に適切に検証され、フォーマットされるようにしています。

## 変更内容
- `recurrence_start` と `recurrence_end` に対して有効な日付であるかどうかを確認する検証を追加し、無効な場合、説明的なエラーを返すようにしました。
- `recurrence_start` と `recurrence_end` を、スプレッドシートのタイムゾーンを使用して `Utilities.formatDate` 関数で `yyyy-MM-dd` 形式に変換し、ペイロードに含める前に処理しました。

## 関連するIssue
- Fixes #8
